### PR TITLE
WIP: multi-line text option support

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
@@ -96,6 +96,10 @@ function Option(data) {
      * list of all multivalue strings to choose from
      */
     self.multiValueList = ko.observableArray(data.multiValueList);
+    /**
+     * rows of textarea form
+     */
+    self.formRows = ko.observable(data.formRows ? data.formRows : 1);
 
     function emptyValue(val) {
         return (!val || val === '');

--- a/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
@@ -47,4 +47,8 @@ function OptionEditor(data) {
     self.isFileType = ko.computed(function () {
         return "file" === self.optionType();
     });
+
+    self.defaultValue = ko.observable(data.defaultValue);
+
+    self.formRows = ko.observable(data.formRows ? data.formRows : 1);
 }

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -68,6 +68,7 @@ public class Option implements Comparable{
     String optionType
     String configData
     Boolean multivalueAllSelected
+    Integer formRows
 
     static belongsTo=[scheduledExecution:ScheduledExecution]
     static transients = ['valuesList', 'realValuesUrl', 'configMap', 'typeFile']
@@ -95,6 +96,7 @@ public class Option implements Comparable{
         configData(nullable: true)
         multivalueAllSelected(nullable: true)
         label(nullable: true)
+        formRows(nullable: true)
     }
 
 
@@ -191,6 +193,9 @@ public class Option implements Comparable{
         if(secureExposed && secureInput){
             map.valueExposed= secureExposed
         }
+        if(null!=formRows){
+            map.formRows=formRows
+        }
         return map
     }
 
@@ -250,6 +255,9 @@ public class Option implements Comparable{
             opt.secureExposed=Boolean.valueOf(data.valueExposed)
         }else{
             opt.secureExposed=false
+        }
+        if(data.formRows!=null){
+            opt.formRows=data.formRows
         }
         return opt
     }
@@ -339,7 +347,7 @@ public class Option implements Comparable{
          'dateFormat', 'values', 'valuesList', 'valuesUrl', 'valuesUrlLong', 'regex', 'multivalued',
          'multivalueAllSelected', 'label',
          'delimiter',
-         'secureInput', 'secureExposed', 'optionType', 'configData'].
+         'secureInput', 'secureExposed', 'optionType', 'configData', 'formRows'].
                 each { k ->
             opt[k]=this[k]
         }
@@ -370,6 +378,7 @@ public class Option implements Comparable{
         ", delimiter='" + delimiter + '\'' +
                 ", optionType='" + optionType + '\'' +
                 ", configData='" + configData + '\'' +
+        ", formRows='" + formRows + '\'' +
         '}' ;
     }
 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -814,6 +814,7 @@ form.option.name.label=Option Name
 form.option.label.label=Option Label
 form.option.type.label=Option Type
 form.option.description.label=Description
+form.option.formRows.label=Form Rows
 form.option.defaultValue.label=Default Value
 form.option.values.label=Allowed Values
 form.label.valuesType.list.label=List

--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -62,6 +62,7 @@ used by _editOptions.gsp template
                                               optionType         : optionSelect.optionType,
 //                                              config             : optionSelect.configMap,
                                               values             : optionSelect.values,
+                                              formRows           : optionSelect.formRows,
                                               defaultValue       : optionSelect.defaultValue,
                                               defaultStoragePath : optionSelect.defaultStoragePath,
                                               multivalued        : optionSelect.multivalued,

--- a/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
@@ -67,11 +67,19 @@
                     </div>
                 </div>
                 <div data-bind="if: !isDate()">
+                    <div data-bind="if: formRows()<=1">
                     <g:textField name="-"
                                  data-bind="value: value, attr: {name: fieldName, id: fieldId}"
                                  class="optionvaluesfield form-control"
                                  value=""
                                  size="40"/>
+                    </div>
+                    <div data-bind="if: formRows()>1">
+                    <g:textArea name="-"
+                                 data-bind="value: value, attr: {name: fieldName, id: fieldId, rows: formRows()}"
+                                 class="optionvaluesfield form-control"
+                                 value="" />
+                    </div>
                 </div>
             </div>
         </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -177,18 +177,42 @@
             </div>
         </div>
         <!-- ko if: !isFileType() -->
+        <div class="form-group opt_keystorage_disabled"
+             style="${wdgt.styleVisible(unless:option?.defaultStoragePath||option?.isDate || option?.secureInput || option?.secureExposed)}">
+            <label class="col-sm-2 control-label"><g:message code="form.option.formRows.label" /></label>
+            <div class="col-sm-10">
+                            <input type="number"
+                                   class="form-control"
+                                   name="formRows"
+                                   id="opt_formRows"
+                                   min="1"
+                                   data-bind="value: formRows"
+                            />
+            </div>
+        </div>
+
         <div class="form-group ${hasErrors(bean: option, field: 'defaultValue', 'has-error')} opt_keystorage_disabled"
              style="${wdgt.styleVisible(unless:option?.defaultStoragePath||option?.isDate || option?.secureInput || option?.secureExposed)}">
             <label class="col-sm-2 control-label"><g:message code="form.option.defaultValue.label" /></label>
             <div class="col-sm-10">
+                <div data-bind="if: formRows()<=1">
                             <input type="text"
                                    class="form-control"
                                    name="defaultValue"
                                    id="opt_defaultValue"
-                                   value="${enc(attr:option?.defaultValue)}"
                                    size="40"
                                    placeholder="Default value"
+                                   data-bind="value: defaultValue"
                             />
+                </div>
+                <div data-bind="if: formRows()>1">
+                            <textarea class="form-control"
+                                      name="defaultValue"
+                                      id="opt_defaultValue"
+                                      placeholder="Default value"
+                                      data-bind="value: defaultValue, attr: {rows: formRows}"
+                            />
+                </div>
             </div>
 
             <g:if test="${origName || option?.name && !newoption}">
@@ -682,7 +706,7 @@
     </div>
     <g:javascript>
       fireWhenReady('optedit_${enc(js: rkey)}',function(){
-          var editor=new OptionEditor({name:"${option?.name}",bashVarPrefix:'${DataContextUtils.ENV_VAR_PREFIX}',optionType:"${option?.optionType}"});
+          var editor=new OptionEditor({name:"${option?.name}",bashVarPrefix:'${DataContextUtils.ENV_VAR_PREFIX}',optionType:"${option?.optionType}",defaultValue:"${option?.defaultValue}",formRows:"${option?.formRows}"});
           ko.applyBindings(editor,jQuery('#optedit_${enc(js:rkey)}')[0]);
       });
     </g:javascript>


### PR DESCRIPTION
This PR addresses https://github.com/rundeck/rundeck/issues/2010

- Added `formRows` job option config to support multi-line text input.
  - It's an integer specifying rows of text input form to render: `<textarea>` when `formRows` > 1, `<input type="text">` otherwise.
  - Newline characters in a form will be lost when you submit it after switching `<textarea>` to `<input type="text">`.
  - It affects both option value forms on job exec and option default value forms on job edit.
- No documentation
- No test

![image](https://user-images.githubusercontent.com/106724/51804464-ae8d7d80-22a4-11e9-8058-f25f90b489a9.png)

![image](https://user-images.githubusercontent.com/106724/51804563-d3362500-22a5-11e9-809b-71aea28fe10f.png)
